### PR TITLE
Improve the mobile UX experience.

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>VibeHQ — Multi-Agent Dashboard</title>
     <style>
       * { margin: 0; padding: 0; box-sizing: border-box; }

--- a/web/src/components/Terminal.tsx
+++ b/web/src/components/Terminal.tsx
@@ -10,6 +10,8 @@ const s: Record<string, React.CSSProperties> = {
         border: '1px solid #30363d',
         borderRadius: '8px',
         overflow: 'hidden',
+        width: '100%',
+        maxWidth: '100vw',
     },
     header: {
         padding: '8px 12px',
@@ -25,6 +27,19 @@ const s: Record<string, React.CSSProperties> = {
     termArea: {
         height: '350px',
         padding: '4px',
+        overflow: 'hidden',
+        position: 'relative' as const,
+    },
+    bottomBtn: {
+        padding: '8px 10px',
+        background: '#21262d',
+        border: '1px solid #30363d',
+        borderRadius: '18px',
+        color: '#c9d1d9',
+        fontSize: '14px',
+        cursor: 'pointer',
+        flexShrink: 0,
+        WebkitTapHighlightColor: 'transparent',
     },
     offline: {
         height: '350px',
@@ -42,6 +57,7 @@ const s: Record<string, React.CSSProperties> = {
         borderTop: '1px solid #30363d',
         flexWrap: 'wrap' as const,
         justifyContent: 'center',
+        overflow: 'hidden',
     },
     tbtn: {
         padding: '6px 10px',
@@ -56,6 +72,55 @@ const s: Record<string, React.CSSProperties> = {
         textAlign: 'center' as const,
         userSelect: 'none' as const,
         WebkitTapHighlightColor: 'transparent',
+    },
+    inputBar: {
+        display: 'flex',
+        gap: '8px',
+        padding: '8px',
+        paddingBottom: 'env(safe-area-inset-bottom, 0px)',
+        background: '#161b22',
+        borderTop: '1px solid #30363d',
+        overflow: 'hidden',
+    },
+    containerFullscreen: {
+        position: 'fixed' as const,
+        top: 0, left: 0, right: 0, bottom: 0,
+        zIndex: 9999,
+        borderRadius: 0,
+        display: 'flex',
+        flexDirection: 'column' as const,
+        background: '#0d1117',
+    },
+    termAreaFullscreen: {
+        flex: 1,
+        height: 'auto',
+        padding: '4px',
+        overflow: 'hidden',
+        position: 'relative' as const,
+    },
+    chatInput: {
+        flex: 1,
+        minWidth: 0,
+        padding: '8px 12px',
+        background: '#0d1117',
+        border: '1px solid #30363d',
+        borderRadius: '18px',
+        color: '#c9d1d9',
+        fontSize: '16px',
+        fontFamily: "'Cascadia Code', 'Fira Code', Menlo, monospace",
+        outline: 'none',
+        boxSizing: 'border-box' as const,
+    },
+    sendBtn: {
+        padding: '8px 16px',
+        background: '#238636',
+        border: 'none',
+        borderRadius: '18px',
+        color: '#ffffff',
+        fontSize: '14px',
+        fontWeight: 600,
+        cursor: 'pointer',
+        flexShrink: 0,
     },
 };
 
@@ -84,13 +149,64 @@ export function Terminal({ team, agentName, isRunning }: Props) {
     const xtermRef = useRef<XTerm | null>(null);
     const wsRef = useRef<WebSocket | null>(null);
     const fitRef = useRef<FitAddon | null>(null);
+    const atBottomRef = useRef(true);
+    const [atBottom, setAtBottom] = useState(true);
     const [connected, setConnected] = useState(false);
     const [isTouch] = useState(() => 'ontouchstart' in window || navigator.maxTouchPoints > 0);
+    const [cmdInput, setCmdInput] = useState('');
+    const [isFullscreen, setIsFullscreen] = useState(false);
+    const isFullscreenRef = useRef(false);
+
+    useEffect(() => { isFullscreenRef.current = isFullscreen; }, [isFullscreen]);
 
     const sendKey = useCallback((seq: string) => {
         if (wsRef.current?.readyState === WebSocket.OPEN) {
             wsRef.current.send(seq);
+            xtermRef.current?.scrollToBottom();
+            atBottomRef.current = true;
+            setAtBottom(true);
         }
+    }, []);
+
+    const handleSendCmd = useCallback((e: React.FormEvent) => {
+        e.preventDefault();
+        if (cmdInput.trim() && wsRef.current?.readyState === WebSocket.OPEN) {
+            wsRef.current.send(cmdInput + '\r');
+            setCmdInput('');
+            xtermRef.current?.scrollToBottom();
+            atBottomRef.current = true;
+            setAtBottom(true);
+        }
+    }, [cmdInput]);
+
+    const scrollHalf = useCallback((direction: 'up' | 'down') => {
+        const xterm = xtermRef.current;
+        if (!xterm) return;
+        const half = Math.max(1, Math.floor(xterm.rows / 2));
+        xterm.scrollLines(direction === 'up' ? -half : half);
+        const buf = (xterm as any).buffer;
+        if (buf) {
+            const isAt = buf.active.viewportY >= buf.active.baseY;
+            atBottomRef.current = isAt;
+            setAtBottom(isAt);
+        }
+    }, []);
+
+    const toggleFullscreen = useCallback(() => {
+        setIsFullscreen(prev => {
+            const next = !prev;
+            isFullscreenRef.current = next;
+            setTimeout(() => {
+                fitRef.current?.fit();
+                const dims = fitRef.current?.proposeDimensions();
+                if (dims?.cols && dims?.rows && wsRef.current?.readyState === WebSocket.OPEN) {
+                    wsRef.current.send(JSON.stringify({ type: 'resize', cols: dims.cols, rows: dims.rows }));
+                }
+            }, 50);
+            if (!next) document.body.style.overflow = '';
+            else document.body.style.overflow = 'hidden';
+            return next;
+        });
     }, []);
 
     useEffect(() => {
@@ -103,7 +219,7 @@ export function Terminal({ team, agentName, isRunning }: Props) {
                 cursor: '#c9d1d9',
                 selectionBackground: '#264f78',
             },
-            fontSize: 13,
+            fontSize: 15,
             fontFamily: "'Cascadia Code', 'Fira Code', Menlo, monospace",
             cursorBlink: true,
             convertEol: true,
@@ -113,6 +229,12 @@ export function Terminal({ team, agentName, isRunning }: Props) {
         xterm.loadAddon(fitAddon);
         xterm.open(termRef.current);
         fitAddon.fit();
+
+        xterm.onScroll(() => {
+            const isAt = xterm.buffer.active.viewportY >= xterm.buffer.active.baseY;
+            atBottomRef.current = isAt;
+            setAtBottom(isAt);
+        });
 
         xtermRef.current = xterm;
         fitRef.current = fitAddon;
@@ -129,7 +251,10 @@ export function Terminal({ team, agentName, isRunning }: Props) {
         };
 
         ws.onmessage = (event) => {
-            xterm.write(event.data);
+            const wasAtBottom = atBottomRef.current;
+            xterm.write(event.data, () => {
+                if (wasAtBottom) xterm.scrollToBottom();
+            });
         };
 
         ws.onclose = () => setConnected(false);
@@ -157,20 +282,60 @@ export function Terminal({ team, agentName, isRunning }: Props) {
             xtermRef.current = null;
             wsRef.current = null;
             fitRef.current = null;
+            atBottomRef.current = true;
+            setAtBottom(true);
+            document.body.style.overflow = '';
         };
     }, [team, agentName, isRunning]);
 
     return (
-        <div style={s.container}>
+        <div style={isFullscreen ? { ...s.container, ...s.containerFullscreen } : s.container}>
             <div style={s.header}>
                 <span>{agentName}</span>
-                <span style={{ fontSize: '11px', color: connected ? '#3fb950' : '#8b949e' }}>
-                    {connected ? 'connected' : isRunning ? 'connecting...' : 'offline'}
-                </span>
+                <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
+                    {isTouch && isRunning && (
+                        <>
+                            <button
+                                type="button"
+                                style={s.bottomBtn}
+                                onTouchStart={(e) => { e.preventDefault(); scrollHalf('up'); }}
+                                onClick={() => scrollHalf('up')}
+                                aria-label="Scroll up half page"
+                            >
+                                ⬆
+                            </button>
+                            <button
+                                type="button"
+                                style={s.bottomBtn}
+                                onTouchStart={(e) => { e.preventDefault(); scrollHalf('down'); }}
+                                onClick={() => scrollHalf('down')}
+                                aria-label="Scroll down half page"
+                            >
+                                ⬇
+                            </button>
+                        </>
+                    )}
+                    <span style={{ fontSize: '11px', color: connected ? '#3fb950' : '#8b949e' }}>
+                        {connected ? 'connected' : isRunning ? 'connecting...' : 'offline'}
+                    </span>
+                    {isRunning && (
+                        <button
+                            style={{ background: 'none', border: 'none', color: '#8b949e', cursor: 'pointer', fontSize: '16px', padding: '0 4px' }}
+                            onTouchStart={(e) => { e.preventDefault(); toggleFullscreen(); }}
+                            onClick={toggleFullscreen}
+                            aria-label={isFullscreen ? 'Exit fullscreen' : 'Fullscreen'}
+                        >
+                            {isFullscreen ? '✕' : '⛶'}
+                        </button>
+                    )}
+                </div>
             </div>
             {isRunning ? (
                 <>
-                    <div ref={termRef} style={s.termArea} />
+                    <div
+                        ref={termRef}
+                        style={isFullscreen ? { ...s.termArea, ...s.termAreaFullscreen } : s.termArea}
+                    />
                     {isTouch && (
                         <div style={s.toolbar}>
                             {KEYS.map(([label, seq]) => (
@@ -183,6 +348,21 @@ export function Terminal({ team, agentName, isRunning }: Props) {
                                 </button>
                             ))}
                         </div>
+                    )}
+                    {isTouch && (
+                        <form style={s.inputBar} onSubmit={handleSendCmd}>
+                            <input
+                                style={s.chatInput}
+                                value={cmdInput}
+                                onChange={(e) => setCmdInput(e.target.value)}
+                                placeholder="Type a command…"
+                                autoComplete="off"
+                                autoCorrect="off"
+                                autoCapitalize="off"
+                                spellCheck={false}
+                            />
+                            <button type="submit" style={s.sendBtn}>Send</button>
+                        </form>
                     )}
                 </>
             ) : (

--- a/web/src/components/Terminal.tsx
+++ b/web/src/components/Terminal.tsx
@@ -152,10 +152,14 @@ export function Terminal({ team, agentName, isRunning }: Props) {
     const atBottomRef = useRef(true);
     const [atBottom, setAtBottom] = useState(true);
     const [connected, setConnected] = useState(false);
+    const [reconnecting, setReconnecting] = useState(false);
     const [isTouch] = useState(() => 'ontouchstart' in window || navigator.maxTouchPoints > 0);
     const [cmdInput, setCmdInput] = useState('');
     const [isFullscreen, setIsFullscreen] = useState(false);
     const isFullscreenRef = useRef(false);
+    const unmountedRef = useRef(false);
+    const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const reconnectDelayRef = useRef(1000);
 
     useEffect(() => { isFullscreenRef.current = isFullscreen; }, [isFullscreen]);
 
@@ -209,8 +213,73 @@ export function Terminal({ team, agentName, isRunning }: Props) {
         });
     }, []);
 
+    const setupWs = useCallback((xterm: XTerm, fitAddon: FitAddon) => {
+        if (wsRef.current) {
+            wsRef.current.onclose = null;
+            wsRef.current.onerror = null;
+            wsRef.current.close();
+        }
+
+        const ws = connectTerminal(team, agentName);
+        wsRef.current = ws;
+
+        ws.onopen = () => {
+            setConnected(true);
+            setReconnecting(false);
+            reconnectDelayRef.current = 1000;
+            const dims = fitAddon.proposeDimensions();
+            if (dims?.cols && dims?.rows) {
+                ws.send(JSON.stringify({ type: 'resize', cols: dims.cols, rows: dims.rows }));
+            }
+        };
+
+        ws.onmessage = (event) => {
+            const wasAtBottom = atBottomRef.current;
+            xterm.write(event.data, () => {
+                if (wasAtBottom) xterm.scrollToBottom();
+            });
+        };
+
+        ws.onclose = () => {
+            setConnected(false);
+            if (!unmountedRef.current) {
+                setReconnecting(true);
+                const delay = reconnectDelayRef.current;
+                reconnectDelayRef.current = Math.min(delay * 2, 10000);
+                reconnectTimerRef.current = setTimeout(() => {
+                    if (!unmountedRef.current && xtermRef.current && fitRef.current) {
+                        setupWs(xtermRef.current, fitRef.current);
+                    }
+                }, delay);
+            }
+        };
+
+        ws.onerror = () => {
+            setConnected(false);
+        };
+
+        xterm.onData((data) => {
+            if (ws.readyState === WebSocket.OPEN) {
+                ws.send(data);
+            }
+        });
+    }, [team, agentName]);
+
+    const handleReconnect = useCallback(() => {
+        if (reconnectTimerRef.current) {
+            clearTimeout(reconnectTimerRef.current);
+            reconnectTimerRef.current = null;
+        }
+        reconnectDelayRef.current = 1000;
+        if (xtermRef.current && fitRef.current) {
+            setReconnecting(true);
+            setupWs(xtermRef.current, fitRef.current);
+        }
+    }, [setupWs]);
+
     useEffect(() => {
         if (!isRunning || !termRef.current) return;
+        unmountedRef.current = false;
 
         const xterm = new XTerm({
             theme: {
@@ -239,45 +308,28 @@ export function Terminal({ team, agentName, isRunning }: Props) {
         xtermRef.current = xterm;
         fitRef.current = fitAddon;
 
-        const ws = connectTerminal(team, agentName);
-        wsRef.current = ws;
-
-        ws.onopen = () => {
-            setConnected(true);
-            const dims = fitAddon.proposeDimensions();
-            if (dims?.cols && dims?.rows) {
-                ws.send(JSON.stringify({ type: 'resize', cols: dims.cols, rows: dims.rows }));
-            }
-        };
-
-        ws.onmessage = (event) => {
-            const wasAtBottom = atBottomRef.current;
-            xterm.write(event.data, () => {
-                if (wasAtBottom) xterm.scrollToBottom();
-            });
-        };
-
-        ws.onclose = () => setConnected(false);
-        ws.onerror = () => setConnected(false);
-
-        xterm.onData((data) => {
-            if (ws.readyState === WebSocket.OPEN) {
-                ws.send(data);
-            }
-        });
+        setupWs(xterm, fitAddon);
 
         const observer = new ResizeObserver(() => {
             fitAddon.fit();
             const dims = fitAddon.proposeDimensions();
-            if (dims?.cols && dims?.rows && ws.readyState === WebSocket.OPEN) {
-                ws.send(JSON.stringify({ type: 'resize', cols: dims.cols, rows: dims.rows }));
+            if (dims?.cols && dims?.rows && wsRef.current?.readyState === WebSocket.OPEN) {
+                wsRef.current.send(JSON.stringify({ type: 'resize', cols: dims.cols, rows: dims.rows }));
             }
         });
         observer.observe(termRef.current);
 
         return () => {
+            unmountedRef.current = true;
+            if (reconnectTimerRef.current) {
+                clearTimeout(reconnectTimerRef.current);
+                reconnectTimerRef.current = null;
+            }
             observer.disconnect();
-            ws.close();
+            if (wsRef.current) {
+                wsRef.current.onclose = null;
+                wsRef.current.close();
+            }
             xterm.dispose();
             xtermRef.current = null;
             wsRef.current = null;
@@ -286,7 +338,7 @@ export function Terminal({ team, agentName, isRunning }: Props) {
             setAtBottom(true);
             document.body.style.overflow = '';
         };
-    }, [team, agentName, isRunning]);
+    }, [team, agentName, isRunning, setupWs]);
 
     return (
         <div style={isFullscreen ? { ...s.container, ...s.containerFullscreen } : s.container}>
@@ -315,9 +367,18 @@ export function Terminal({ team, agentName, isRunning }: Props) {
                             </button>
                         </>
                     )}
-                    <span style={{ fontSize: '11px', color: connected ? '#3fb950' : '#8b949e' }}>
-                        {connected ? 'connected' : isRunning ? 'connecting...' : 'offline'}
+                    <span style={{ fontSize: '11px', color: connected ? '#3fb950' : reconnecting ? '#d29922' : '#8b949e' }}>
+                        {connected ? 'connected' : reconnecting ? 'reconnecting...' : isRunning ? 'connecting...' : 'offline'}
                     </span>
+                    {isRunning && !connected && (
+                        <button
+                            style={{ background: 'none', border: '1px solid #30363d', borderRadius: '4px', color: '#58a6ff', cursor: 'pointer', fontSize: '11px', padding: '2px 8px' }}
+                            onClick={handleReconnect}
+                            aria-label="Reconnect terminal"
+                        >
+                            reconnect
+                        </button>
+                    )}
                     {isRunning && (
                         <button
                             style={{ background: 'none', border: 'none', color: '#8b949e', cursor: 'pointer', fontSize: '16px', padding: '0 4px' }}


### PR DESCRIPTION
## Summary

  Improve the mobile/touch UX for the VibeHQ terminal component, making it significantly more usable on phones and tablets.

  ## Problem

  The web terminal was designed primarily for desktop use, making it difficult to interact with on mobile devices:
  - No way to type commands without a physical keyboard — the on-screen keyboard obscured the terminal and there was no dedicated input field
  - No way to scroll through terminal output on touch devices (no half-page scroll controls)
  - The terminal was cramped on small screens with no fullscreen mode
  - Small font size (13px) was hard to read on mobile
  - The viewport didn't account for safe area insets (notches, rounded corners)
  - Terminal output could overflow its container on narrow screens

  ## Solution

  **Chat-style command input** — Added a persistent input bar at the bottom (touch devices only) with a text field and send button, so users can type and submit commands without fighting
  the on-screen keyboard.

  **Fullscreen mode** — Added a toggle that expands the terminal to fill the entire viewport (`position: fixed`), with proper resize signaling to the PTY backend. Includes body scroll
  lock and a close button.

  **Scroll controls** — Added half-page up/down buttons in the header bar (touch devices only), plus auto-scroll-to-bottom behavior that tracks whether the user is at the bottom and
  preserves their scroll position when new output arrives.

  **Visual/layout fixes:**
  - Bumped font size from 13px to 15px for mobile readability
  - Added `viewport-fit=cover` meta tag for safe area inset support
  - Added `width: 100%` / `max-width: 100vw` to prevent horizontal overflow
  - Used `env(safe-area-inset-bottom)` padding on the input bar for notched devices
  - Added `WebkitTapHighlightColor: 'transparent'` to eliminate tap flash on iOS